### PR TITLE
Change host parameter type to `Into<String>`

### DIFF
--- a/examples/connecting.rs
+++ b/examples/connecting.rs
@@ -5,7 +5,7 @@ use std::io::Cursor;
 use ftp::FTPStream;
 
 fn main() {
-	let mut ftp_stream = match FTPStream::connect("127.0.0.1".to_string(), 21) {
+	let mut ftp_stream = match FTPStream::connect("127.0.0.1", 21) {
         Ok(s) => s,
         Err(e) => panic!("{}", e)
     };

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use regex::Regex;
 
 /// Stream to interface with the FTP server. This interface is only for the command stream.
+#[derive(Debug)]
 pub struct FTPStream {
 	command_stream: TcpStream,
 	pub host: String,

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -20,12 +20,13 @@ pub struct FTPStream {
 impl FTPStream {
 
 	/// Creates an FTP Stream.
-	pub fn connect(host: String, port: u16) -> Result<FTPStream, Error> {
-		let connect_string = format!("{}:{}", host, port);
+	pub fn connect<S: Into<String>>(host: S, port: u16) -> Result<FTPStream, Error> {
+        let host_string = host.into();
+		let connect_string = format!("{}:{}", host_string, port);
 		let tcp_stream = try!(TcpStream::connect(&*connect_string));
 		let mut ftp_stream = FTPStream {
 			command_stream: tcp_stream,
-			host: host,
+			host: host_string,
 			command_port: port
 		};
 		match ftp_stream.read_response(220) {


### PR DESCRIPTION
I learned some new stuff since my [last PR](https://github.com/mattnenterprise/rust-ftp/pull/6) :)

Instead of using `String` as the parameter type, you should use `Into<String>`. This allows the user to pass in anything that implements `Into<String>`, e.g. a 'static string slice. So this works again (and is more ergonomic):

    let ftp_stream = match FTPStream::connect("127.0.0.1", 21);