### PR TITLE
Add a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+This project follows semantic versioning.
+
+Possible log types:
+
+- `[added]` for new features.
+- `[changed]` for changes in existing functionality.
+- `[deprecated]` for once-stable features removed in upcoming releases.
+- `[removed]` for deprecated features removed in this release.
+- `[fixed]` for any bug fixes.
+- `[security]` to invite users to upgrade in case of vulnerabilities.
+
+
+### [Unreleased]
+
+- [changed] The `FTPStream` struct was renamed to `FtpStream` (#17)
+- [added] The `host` parameter for `FtpStream` now accepts any type that
+  implements `Into<String>` (#13)
+- [changed] FTP return code type changed from `isize` to `u32` (#18)
+- [changed] Type of port number returned by `pasv` changed from `isize`
+  to `u32` (#18)
+- [changed] Improved error handling (#21)
+- ...
+
+
+### [v0.0.7] (2016-01-11)
+
+- No changelog up to this point
+
+[Unreleased]: https://github.com/coredump-ch/coredumpbot/compare/761deb8...HEAD
+[0.0.7]: https://github.com/mattnenterprise/rust-ftp/compare/ef996f0...761deb8


### PR DESCRIPTION
For reasons to keep a changelog, see
https://blog.dbrgn.ch/2015/12/1/rust-crates-keep-a-changelog/.

I prefer a manual changelog over generating one from conventional
commit message format. First of all it does not require you to follow
detailed conventions when naming your commits. Furthermore, a human can
summarize changes in a better way than a software tool.

Ideally the repository will include tags for all released versions in
the future (e.g. `v0.0.8` for the next release). Then these tags can be
used in the CHANGELOG instead of commit IDs.
(You could also tag the old releases that were made in the past.)