### PR TITLE
List commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ Possible log types:
 ### [Unreleased from branch list_commands]
 - [changed] Separate main lib file and FTP stream implementation.
 - [changed] Regex is used to parse PASV response.
-- [added] The implementation of LIST command. See method `list`.
-- [added] The implementation of NLST command. See method `nlst`.
-- [added] The implementation of MDTM command. See method `mdtm`.
+- [added] The implementation of LIST command. See method `FtpStream::list`.
+- [added] The implementation of NLST command. See method `FtpStream::nlst`.
+- [added] The implementation of MDTM command. See method `FtpStream::mdtm`.
+- [added] The implementation of SIZE command. See method `FtpStream::size`.
 
 
 ### [v0.0.7] (2016-01-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Possible log types:
 - [changed] Improved error handling (#21)
 - ...
 
+### [Unreleased branch list_commands]
+- [changed] Separate main lib file and FTP stream implementation.
+
 
 ### [v0.0.7] (2016-01-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Possible log types:
 ### [Unreleased from branch list_commands]
 - [changed] Separate main lib file and FTP stream implementation.
 - [changed] Regex is used to parse PASV response.
+- [added] The implementation of LIST command. See method `list`.
+- [added] The implementation of NLST command. See method `nlst`.
 
 
 ### [v0.0.7] (2016-01-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ Possible log types:
 - [changed] Improved error handling (#21)
 - ...
 
-### [Unreleased branch list_commands]
+### [Unreleased from branch list_commands]
 - [changed] Separate main lib file and FTP stream implementation.
+- [changed] Regex is used to parse PASV response.
 
 
 ### [v0.0.7] (2016-01-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Possible log types:
 - [changed] Regex is used to parse PASV response.
 - [added] The implementation of LIST command. See method `list`.
 - [added] The implementation of NLST command. See method `nlst`.
+- [added] The implementation of MDTM command. See method `mdtm`.
 
 
 ### [v0.0.7] (2016-01-11)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ license = "MIT OR Apache-2.0"
 [lib]
 name ="ftp"
 path = "src/lib.rs"
+
+[dependencies]
+lazy_static = "*"
+regex = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ path = "src/lib.rs"
 [dependencies]
 lazy_static = "*"
 regex = "*"
+chrono = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT OR Apache-2.0"
 
 [lib]
 name ="ftp"
-path = "src/ftp.rs"
+path = "src/lib.rs"

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -1,27 +1,8 @@
-#![crate_name = "ftp"]
-#![crate_type = "lib"]
-
-//! ftp is an FTP client written in Rust.
-//!
-//! ### Usage
-//!
-//! Here is a basic usage example:
-//!
-//! ```rust
-//! use ftp::FtpStream;
-//! let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap_or_else(|err|
-//!     panic!("{}", err)
-//! );
-//! let _ = ftp_stream.quit();
-//! ```
-//!
-
 use std::io::{Error, ErrorKind, Read, Result, BufRead, BufReader, BufWriter, Cursor, Write, copy};
 use std::net::TcpStream;
 use std::string::String;
 use std::net::ToSocketAddrs;
-
-pub mod status;
+use super::status;
 
 /// Stream to interface with the FTP server. This interface is only for the command stream.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 
 #[macro_use] extern crate lazy_static;
 extern crate regex;
+extern crate chrono;
 
 mod ftp;
 pub mod status;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@
 //! ```
 //!
 
+#[macro_use] extern crate lazy_static;
+extern crate regex;
+
 mod ftp;
 pub mod status;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,22 @@
+#![crate_name = "ftp"]
+#![crate_type = "lib"]
+
+//! ftp is an FTP client written in Rust.
+//!
+//! ### Usage
+//!
+//! Here is a basic usage example:
+//!
+//! ```rust
+//! use ftp::FtpStream;
+//! let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap_or_else(|err|
+//!     panic!("{}", err)
+//! );
+//! let _ = ftp_stream.quit();
+//! ```
+//!
+
+mod ftp;
+pub mod status;
+
+pub use self::ftp::FtpStream;


### PR DESCRIPTION
Hello,

this pr includes:
* Implementations of `LIST`, `NLST`, `MDTM`, `SIZE` commands.
* Fixed the parsing of `PASV` response using regex.
* Separated lib main file and FTP stream implementation because it will be difficult to have lib level documentation and implementation in one file.