### PR TITLE
RETR and TYPE

### DIFF
--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -6,6 +6,7 @@ use regex::Regex;
 use chrono::{DateTime, UTC};
 use chrono::offset::TimeZone;
 use super::status;
+use super::types::FileType;
 
 lazy_static! {
     // This regex extracts IP and Port details from PASV command response.
@@ -125,6 +126,15 @@ impl FtpStream {
                 }
             }
         })
+    }
+
+    /// Sets the type of file to be transferred. That is the implementation
+    /// of `TYPE` command.
+    pub fn transfer_type(&mut self, file_type: FileType) -> Result<()> {
+        let type_command = format!("TYPE {}\r\n", file_type.to_string());
+        try!(self.write_str(&type_command));
+        try!(self.read_response(status::COMMAND_OK));
+        Ok(())
     }
 
     /// Quits the current FTP session.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate regex;
 extern crate chrono;
 
 mod ftp;
+pub mod types;
 pub mod status;
 
 pub use self::ftp::FtpStream;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,54 @@
+//! The set of valid values for FTP commands
+
+
+/// Text Format Control used in `TYPE` command
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FormatControl {
+	/// Default text format control (is NonPrint)
+	Default,
+	/// Non-print (not destined for printing)
+	NonPrint,
+	/// Telnet format control (\<CR\>, \<FF\>, etc.)
+	Telnet,
+	/// ASA (Fortran) Carriage Control
+	Asa,
+}
+
+
+/// File Type used in `TYPE` command
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FileType {
+	/// ASCII text (the argument is the text format control)
+	Ascii(FormatControl),
+	/// EBCDIC text (the argument is the text format control)
+	Ebcdic(FormatControl),
+	/// Image,
+	Image,
+	/// Binary (the synonym to Image)
+	Binary,
+	/// Local format (the argument is the number of bits in one byte on local machine)
+	Local(u8),
+}
+
+
+impl ToString for FormatControl {
+	fn to_string(&self) -> String {
+		match self {
+			&FormatControl::Default | &FormatControl::NonPrint => String::from("N"),
+			&FormatControl::Telnet => String::from("T"),
+			&FormatControl::Asa => String::from("C"),
+		}
+	}
+}
+
+
+impl ToString for FileType {
+	fn to_string(&self) -> String {
+		match self {
+			&FileType::Ascii(ref fc) => format!("A {}", fc.to_string()),
+			&FileType::Ebcdic(ref fc) => format!("E {}", fc.to_string()),
+			&FileType::Image | &FileType::Binary => String::from("I"),
+			&FileType::Local(ref bits) => format!("L {}", bits),
+		}
+	}
+}


### PR DESCRIPTION
Hello,

the current implementation of `RETR` (`FtpStream::get`) is not correct because it does not read response lines after the data stream is read and closed and using the simple implementation (`FtpStream::simple_retr`) is not a good idea when files for downloading are big. In the PR I added a new function `FtpStream::retr` which takes an additional argument `reader` which is a closure which operates the data stream and inside `retr` all repsonses and dropping of the data stream are handled correctly.

In the PR I also added `TYPE` (`FtpStream::transfer_type`) function which is very important when the binary file should be transfered.