### PR TITLE
FTPS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ Possible log types:
 - [added] The implementation of MDTM command. See method `FtpStream::mdtm`.
 - [added] The implementation of SIZE command. See method `FtpStream::size`.
 
+### [Unreleased from branch retr_and_type]
+- [added] The implementation of RETR command. See method `FtpStream::retr`.
+- [added] The implementation of TYPE command. See method `FtpStream::transfer_type`.
+
+### [Unreleased from branch ftps_support]
+- [added] Feature `secure` to enable FTPS support. Disabled be default.
+- [added] Feature `debug_print` to print command and responses to STDOUT. Disabled be default.
+- [added] DataStream which hides the underlying secure or insecure TCP stream.
+- [changed] Methods return `DataStream` instead of `TcpStream`.
+- [changed] Method `pasv` returns only IP and port and do not open new TCP stream.
+- [added] Method `data_command` which issues `pasv` to open the new `DataStream`.
+- [added] Methods `secure` and `insecure` to switch between secure and insecure modes.
+
 
 ### [v0.0.7] (2016-01-11)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "ftp"
 version = "0.0.7"
 authors = ["Matt McCoy <mattnenterprise@yahoo.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 
 [features]
 secure = ["openssl"]
+debug_print = []
 
 [dependencies]
 lazy_static = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,14 @@ license = "MIT OR Apache-2.0"
 name ="ftp"
 path = "src/lib.rs"
 
+[features]
+secure = ["openssl"]
+
 [dependencies]
-lazy_static = "*"
-regex = "*"
-chrono = "*"
+lazy_static = "0.1"
+regex = "0.1"
+chrono = "0.2"
+
+[dependencies.openssl]
+version = "0.7"
+optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,11 @@ name ="ftp"
 path = "src/lib.rs"
 
 [features]
+# Enable support of FTPS which requires openssl
 secure = ["openssl"]
+
+# Add debug output (to STDOUT) of commands sent to the server
+# and lines read from the server
 debug_print = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Add ftp via your `Cargo.toml`
 ftp = "*"
 ```
 
+FTPS support is disabled by default. To enable it activate feature `secure` in `Cargo.toml`.
+```toml
+[dependencies]
+ftp = { version = "*", features = ["secure"] }
+```
+
 ### Usage
 ```rs
 extern crate ftp;

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add ftp via your `Cargo.toml`
 ftp = "*"
 ```
 
-FTPS support is disabled by default. To enable it activate feature `secure` in `Cargo.toml`.
+FTPS support is disabled by default. To enable it `secure` should be activated in `Cargo.toml`.
 ```toml
 [dependencies]
 ftp = { version = "*", features = ["secure"] }

--- a/src/data_stream.rs
+++ b/src/data_stream.rs
@@ -1,0 +1,43 @@
+use std::io::{Read, Write, Result};
+use std::net::TcpStream;
+#[cfg(feature = "secure")]
+use openssl::ssl::SslStream;
+
+
+/// Data Stream used for communications
+#[derive(Debug)]
+pub enum DataStream {
+    Tcp(TcpStream),
+    #[cfg(feature = "secure")]
+	Ssl(SslStream<TcpStream>),
+}
+
+
+impl Read for DataStream {
+	fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+		match self {
+			&mut DataStream::Tcp(ref mut stream) => stream.read(buf),
+			#[cfg(feature = "secure")]
+			&mut DataStream::Ssl(ref mut stream) => stream.read(buf),
+		}
+	}
+}
+
+
+impl Write for DataStream {
+	fn write(&mut self, buf: &[u8]) -> Result<usize> {
+		match self {
+			&mut DataStream::Tcp(ref mut stream) => stream.write(buf),
+			#[cfg(feature = "secure")]
+			&mut DataStream::Ssl(ref mut stream) => stream.write(buf),
+		}
+	}
+
+    fn flush(&mut self) -> Result<()> {
+		match self {
+			&mut DataStream::Tcp(ref mut stream) => stream.flush(),
+			#[cfg(feature = "secure")]
+			&mut DataStream::Ssl(ref mut stream) => stream.flush(),
+		}
+    }
+}

--- a/src/data_stream.rs
+++ b/src/data_stream.rs
@@ -9,54 +9,54 @@ use openssl::ssl::SslStream;
 pub enum DataStream {
     Tcp(TcpStream),
     #[cfg(feature = "secure")]
-	Ssl(SslStream<TcpStream>),
+    Ssl(SslStream<TcpStream>),
 }
 
 
 #[cfg(feature = "secure")]
 impl DataStream {
-	/// Unwrap the stream into TcpStream. This method is only used in secure connection.
-	pub fn into_tcp_stream(self) -> TcpStream {
-		match self {
-			DataStream::Tcp(stream) => stream,
-			DataStream::Ssl(stream) => stream.get_ref().try_clone().unwrap(),
-		}
-	}
+    /// Unwrap the stream into TcpStream. This method is only used in secure connection.
+    pub fn into_tcp_stream(self) -> TcpStream {
+        match self {
+            DataStream::Tcp(stream) => stream,
+            DataStream::Ssl(stream) => stream.get_ref().try_clone().unwrap(),
+        }
+    }
 
-	/// Test if the stream is secured
-	pub fn is_ssl(&self) -> bool {
-		match self {
-		    &DataStream::Ssl(_) => true,
-		    _ => false
-		}
-	}
+    /// Test if the stream is secured
+    pub fn is_ssl(&self) -> bool {
+        match self {
+            &DataStream::Ssl(_) => true,
+            _ => false
+        }
+    }
 }
 
 impl Read for DataStream {
-	fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-		match self {
-			&mut DataStream::Tcp(ref mut stream) => stream.read(buf),
-			#[cfg(feature = "secure")]
-			&mut DataStream::Ssl(ref mut stream) => stream.read(buf),
-		}
-	}
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self {
+            &mut DataStream::Tcp(ref mut stream) => stream.read(buf),
+            #[cfg(feature = "secure")]
+            &mut DataStream::Ssl(ref mut stream) => stream.read(buf),
+        }
+    }
 }
 
 
 impl Write for DataStream {
-	fn write(&mut self, buf: &[u8]) -> Result<usize> {
-		match self {
-			&mut DataStream::Tcp(ref mut stream) => stream.write(buf),
-			#[cfg(feature = "secure")]
-			&mut DataStream::Ssl(ref mut stream) => stream.write(buf),
-		}
-	}
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        match self {
+            &mut DataStream::Tcp(ref mut stream) => stream.write(buf),
+            #[cfg(feature = "secure")]
+            &mut DataStream::Ssl(ref mut stream) => stream.write(buf),
+        }
+    }
 
     fn flush(&mut self) -> Result<()> {
-		match self {
-			&mut DataStream::Tcp(ref mut stream) => stream.flush(),
-			#[cfg(feature = "secure")]
-			&mut DataStream::Ssl(ref mut stream) => stream.flush(),
-		}
+        match self {
+            &mut DataStream::Tcp(ref mut stream) => stream.flush(),
+            #[cfg(feature = "secure")]
+            &mut DataStream::Ssl(ref mut stream) => stream.flush(),
+        }
     }
 }

--- a/src/data_stream.rs
+++ b/src/data_stream.rs
@@ -13,6 +13,25 @@ pub enum DataStream {
 }
 
 
+#[cfg(feature = "secure")]
+impl DataStream {
+	/// Unwrap the stream into TcpStream. This method is only used in secure connection.
+	pub fn into_tcp_stream(self) -> TcpStream {
+		match self {
+			DataStream::Tcp(stream) => stream,
+			DataStream::Ssl(stream) => stream.get_ref().try_clone().unwrap(),
+		}
+	}
+
+	/// Test if the stream is secured
+	pub fn is_ssl(&self) -> bool {
+		match self {
+		    &DataStream::Ssl(_) => true,
+		    _ => false
+		}
+	}
+}
+
 impl Read for DataStream {
 	fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
 		match self {

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -93,7 +93,7 @@ impl FtpStream {
             // Initialize SSL and make the opened stream secured
             let ssl = match Ssl::new(&SSL_CONTEXT) {
                 Ok(ssl) => ssl,
-                Err(e) => return (self, Err(Error::new(ErrorKind::Other, e)))
+                Err(e) => panic!("error: cannot create SSL context: {}", e)
             };
 
             let stream = match SslStream::connect(ssl, self.reader.into_inner().into_tcp_stream()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,11 @@
 #[macro_use] extern crate lazy_static;
 extern crate regex;
 extern crate chrono;
+#[cfg(feature = "secure")]
+extern crate openssl;
 
 mod ftp;
+mod data_stream;
 pub mod types;
 pub mod status;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 //!
 //! The client uses explicit mode for connecting FTPS what means you should
 //! connect the server as usually and then switch to the secure mode (TLS is used).
+//! For better security it's the good practice to switch to the secure mode
+//! before authentication.
 //!
 //! ### FTPS Usage
 //!
@@ -31,14 +33,14 @@
 //! let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
 //! // Switch to the secure mode
 //! let mut ftp_stream = ftp_stream.secure();
-//! // Do all secret things
+//! ftp_stream.login("anonymous", "anonymous").unwrap();
+//! // Do other secret stuff
 //! // Switch back to the insecure mode (if required)
 //! let mut ftp_stream = ftp_stream.insecure();
-//! // Do all public things
+//! // Do all public stuff
 //! let _ = ftp_stream.quit();
 //! ```
 //!
-
 
 
 #[macro_use] extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,31 @@
 //! let _ = ftp_stream.quit();
 //! ```
 //!
+//! ### FTPS
+//!
+//! The client supports FTPS on demand. To enable it the client should be
+//! compiled with feature `openssl` enabled what requires
+//! [openssl](https://crates.io/crates/openssl) dependency.
+//!
+//! The client uses explicit mode for connecting FTPS what means you should
+//! connect the server as usually and then switch to the secure mode (TLS is used).
+//!
+//! ### FTPS Usage
+//!
+//! ```rust
+//! use ftp::FtpStream;
+//! let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
+//! // Switch to the secure mode
+//! let mut ftp_stream = ftp_stream.secure();
+//! // Do all secret things
+//! // Switch back to the insecure mode (if required)
+//! let mut ftp_stream = ftp_stream.insecure();
+//! // Do all public things
+//! let _ = ftp_stream.quit();
+//! ```
+//!
+
+
 
 #[macro_use] extern crate lazy_static;
 extern crate regex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,11 @@
 //! use ftp::FtpStream;
 //! let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
 //! // Switch to the secure mode
-//! let mut ftp_stream = ftp_stream.secure();
+//! let (mut ftp_stream, _) = ftp_stream.secure();
 //! ftp_stream.login("anonymous", "anonymous").unwrap();
 //! // Do other secret stuff
 //! // Switch back to the insecure mode (if required)
-//! let mut ftp_stream = ftp_stream.insecure();
+//! let (mut ftp_stream, _) = ftp_stream.insecure();
 //! // Do all public stuff
 //! let _ = ftp_stream.quit();
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ### FTPS Usage
 //!
-//! ```rust
+//! ```no_run
 //! use ftp::FtpStream;
 //! let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
 //! // Switch to the secure mode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ### FTPS Usage
 //!
-//! ```no_run
+//! ```ignore
 //! use ftp::FtpStream;
 //! let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
 //! // Switch to the secure mode

--- a/src/status.rs
+++ b/src/status.rs
@@ -23,6 +23,7 @@ pub const EXTENDED_PASSIVE_MODE: u32       = 229;
 pub const LOGGED_IN: u32                   = 230;
 pub const LOGGED_OUT: u32                  = 231;
 pub const LOGOUT_ACK: u32                  = 232;
+pub const AUTH_OK: u32                     = 234;
 pub const REQUESTED_FILE_ACTION_OK: u32    = 250;
 pub const PATH_CREATED: u32                = 257;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,51 +4,51 @@
 /// Text Format Control used in `TYPE` command
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FormatControl {
-	/// Default text format control (is NonPrint)
-	Default,
-	/// Non-print (not destined for printing)
-	NonPrint,
-	/// Telnet format control (\<CR\>, \<FF\>, etc.)
-	Telnet,
-	/// ASA (Fortran) Carriage Control
-	Asa,
+    /// Default text format control (is NonPrint)
+    Default,
+    /// Non-print (not destined for printing)
+    NonPrint,
+    /// Telnet format control (\<CR\>, \<FF\>, etc.)
+    Telnet,
+    /// ASA (Fortran) Carriage Control
+    Asa,
 }
 
 
 /// File Type used in `TYPE` command
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FileType {
-	/// ASCII text (the argument is the text format control)
-	Ascii(FormatControl),
-	/// EBCDIC text (the argument is the text format control)
-	Ebcdic(FormatControl),
-	/// Image,
-	Image,
-	/// Binary (the synonym to Image)
-	Binary,
-	/// Local format (the argument is the number of bits in one byte on local machine)
-	Local(u8),
+    /// ASCII text (the argument is the text format control)
+    Ascii(FormatControl),
+    /// EBCDIC text (the argument is the text format control)
+    Ebcdic(FormatControl),
+    /// Image,
+    Image,
+    /// Binary (the synonym to Image)
+    Binary,
+    /// Local format (the argument is the number of bits in one byte on local machine)
+    Local(u8),
 }
 
 
 impl ToString for FormatControl {
-	fn to_string(&self) -> String {
-		match self {
-			&FormatControl::Default | &FormatControl::NonPrint => String::from("N"),
-			&FormatControl::Telnet => String::from("T"),
-			&FormatControl::Asa => String::from("C"),
-		}
-	}
+    fn to_string(&self) -> String {
+        match self {
+            &FormatControl::Default | &FormatControl::NonPrint => String::from("N"),
+            &FormatControl::Telnet => String::from("T"),
+            &FormatControl::Asa => String::from("C"),
+        }
+    }
 }
 
 
 impl ToString for FileType {
-	fn to_string(&self) -> String {
-		match self {
-			&FileType::Ascii(ref fc) => format!("A {}", fc.to_string()),
-			&FileType::Ebcdic(ref fc) => format!("E {}", fc.to_string()),
-			&FileType::Image | &FileType::Binary => String::from("I"),
-			&FileType::Local(ref bits) => format!("L {}", bits),
-		}
-	}
+    fn to_string(&self) -> String {
+        match self {
+            &FileType::Ascii(ref fc) => format!("A {}", fc.to_string()),
+            &FileType::Ebcdic(ref fc) => format!("E {}", fc.to_string()),
+            &FileType::Image | &FileType::Binary => String::from("I"),
+            &FileType::Local(ref bits) => format!("L {}", bits),
+        }
+    }
 }


### PR DESCRIPTION
Hello,

implemented FTPS support using Private Protection mode what means both commands and data are secured with TLS. FTPS is a feature which is disabled be default because it introduces `openssl` dependency. To enable it feature `secure` should be activated in toml or directly in the build command `cargo build/test/doc --features "secure"`.

Also I introduce `DataStream` struct in the PR which abstracts `FtpStream` for the underlying stream (TCP or SSL over TCP).

And I added a feature `debug_output` which on activation prints all commands and responses to STDOUT. Very usefull when debugging.