### PR TITLE
README: syntax highlighting fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ftp = { version = "*", features = ["secure"] }
 ```
 
 ### Usage
-```rs
+```rust
 extern crate ftp;
 
 use std::str;


### PR DESCRIPTION
This fixes the syntax highlighting for the Rust code by using the `rust` language for the fenced code block.
