### PR TITLE
Fix and simplify README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ use ftp::FtpStream;
 
 fn main() {
     // Create a connection to an FTP server and authenticate to it.
-	  let mut ftp_stream = match FtpStream::connect("127.0.0.1:21").unwrap();
-    let _ ftp_stream.login("username", "password").unwrap();
+	  let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
+    let _ = ftp_stream.login("username", "password").unwrap();
 
     // Get the current directory that the client will be reading from and writing to.
     println!("Current directory: {}", ftp_stream.pwd().unwrap());

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use std::io::Cursor;
 use ftp::FtpStream;
 
 fn main() {
-	let mut ftp_stream = match FtpStream::connect("127.0.0.1", 21) {
+	let mut ftp_stream = match FtpStream::connect("127.0.0.1:21") {
         Ok(s) => s,
         Err(e) => panic!("{}", e)
     };
@@ -65,7 +65,7 @@ fn main() {
     //Store a file
     let file_data = format!("Some awesome file data man!!");
     let reader: &mut Cursor<Vec<u8>> = &mut Cursor::new(file_data.into_bytes());
-    match ftp_stream.stor("my_random_file.txt", reader) {
+    match ftp_stream.put("my_random_file.txt", reader) {
         Ok(_) => (),
         Err(e) => panic!("{}", e)
     }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fn main() {
     let _ = ftp_stream.cwd("test_data").unwrap();
 
     // Retrieve (GET) a file from the FTP server in the current working directory.
-    let remote_file = match ftp_stream.simple_retr("ftpext-charter.txt").unwrap()
+    let remote_file = ftp_stream.simple_retr("ftpext-charter.txt").unwrap();
     println!("Read file with contents\n{}\n", str::from_utf8(&remote_file.into_inner()).unwrap());
 
     // Store (PUT) a file from the client to the current working directory of the server.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ fn main() {
     let _ ftp_stream.login("username", "password").unwrap();
 
     // Get the current directory that the client will be reading from and writing to.
-    println!("Current directory: {}", ftp_stream.current_dir().unwrap());
+    println!("Current directory: {}", ftp_stream.pwd().unwrap());
     
     // Change into a new directory, relative to the one we are currently in.
-    let _ = ftp_stream.change_dir("test_data").unwrap();
+    let _ = ftp_stream.cwd("test_data").unwrap();
 
     // Retrieve (GET) a file from the FTP server in the current working directory.
     let remote_file = match ftp_stream.simple_retr("ftpext-charter.txt").unwrap()

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ use ftp::FtpStream;
 
 fn main() {
     // Create a connection to an FTP server and authenticate to it.
-	  let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
+    let mut ftp_stream = FtpStream::connect("127.0.0.1:21").unwrap();
     let _ = ftp_stream.login("username", "password").unwrap();
 
     // Get the current directory that the client will be reading from and writing to.

--- a/README.md
+++ b/README.md
@@ -31,45 +31,26 @@ use std::io::Cursor;
 use ftp::FtpStream;
 
 fn main() {
-	let mut ftp_stream = match FtpStream::connect("127.0.0.1:21") {
-        Ok(s) => s,
-        Err(e) => panic!("{}", e)
-    };
+    // Create a connection to an FTP server and authenticate to it.
+	  let mut ftp_stream = match FtpStream::connect("127.0.0.1:21").unwrap();
+    let _ ftp_stream.login("username", "password").unwrap();
 
-    match ftp_stream.login("username", "password") {
-        Ok(_) => (),
-        Err(e) => panic!("{}", e)
-    }
+    // Get the current directory that the client will be reading from and writing to.
+    println!("Current directory: {}", ftp_stream.current_dir().unwrap());
+    
+    // Change into a new directory, relative to the one we are currently in.
+    let _ = ftp_stream.change_dir("test_data").unwrap();
 
-    match ftp_stream.current_dir() {
-        Ok(dir) => println!("{}", dir),
-        Err(e) => panic!("{}", e)
-    }
+    // Retrieve (GET) a file from the FTP server in the current working directory.
+    let remote_file = match ftp_stream.simple_retr("ftpext-charter.txt").unwrap()
+    println!("Read file with contents\n{}\n", str::from_utf8(&remote_file.into_inner()).unwrap());
 
-    match ftp_stream.change_dir("test_data") {
-        Ok(_) => (),
-        Err(e) => panic!("{}", e)
-    }
+    // Store (PUT) a file from the client to the current working directory of the server.
+    let mut reader = Cursor::new("Hello from the Rust \"ftp\" crate!".as_bytes());
+    let _ = ftp_stream.put("greeting.txt", &mut reader);
+    println!("Successfully wrote greeting.txt");
 
-    //An easy way to retreive a file
-    let remote_file = match ftp_stream.simple_retr("ftpext-charter.txt") {
-        Ok(file) => file,
-        Err(e) => panic!("{}", e)
-    };
-
-    match str::from_utf8(&remote_file.into_inner()) {
-        Ok(s) => print!("{}", s),
-        Err(e) => panic!("Error reading file data: {}", e)
-    };
-
-    //Store a file
-    let file_data = format!("Some awesome file data man!!");
-    let reader: &mut Cursor<Vec<u8>> = &mut Cursor::new(file_data.into_bytes());
-    match ftp_stream.put("my_random_file.txt", reader) {
-        Ok(_) => (),
-        Err(e) => panic!("{}", e)
-    }
-
+    // Terminate the connection to the server.
     let _ = ftp_stream.quit();
 }
 


### PR DESCRIPTION
A good README example is really important, and I'm glad this library has one. However, it needed a couple things.

1. The example was out of date and not consistent with the current API provided by the library.
2. (My opinion) The example was a bit convoluted by making such extensive use of the `match` statement. Since it's just an example, and not production code, I simplified things by adhering to the trend in most crates to just `unwrap()` results so we can easily see what the program is supposed to do.

In the future, could I ask you, @mattnenterprise, to try to adhere more closely to the practices suggested by [Semantic Versioning](http://semver.org/) and increment the major version number when changes to the API (such as name changes, argument type changes, return types) take place?

Cheers!