### PR TITLE
use log crate for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,11 @@ path = "src/lib.rs"
 # Enable support of FTPS which requires openssl
 secure = ["openssl"]
 
-# Add debug output (to STDOUT) of commands sent to the server
-# and lines read from the server
-debug_print = []
-
 [dependencies]
 lazy_static = "0.1"
 regex = "0.1"
 chrono = "0.2"
+log = "0.3"
 
 [dependencies.openssl]
 version = "0.7"

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -451,9 +451,7 @@ impl FtpStream {
     }
 
     fn write_str<S: AsRef<str>>(&mut self, command: S) -> Result<()> {
-        if cfg!(feature = "debug_print") {
-            print!("CMD {}", command.as_ref());
-        }
+        debug!("CMD {}", command.as_ref());
 
         let stream = self.reader.get_mut();
         stream.write_all(command.as_ref().as_bytes())
@@ -470,9 +468,7 @@ impl FtpStream {
         try!(self.reader.read_line(&mut line)
              .map_err(|read_err| FtpError::ConnectionError(read_err)));
 
-        if cfg!(feature = "debug_print") {
-            print!("FTP {}", line);
-        }
+        debug!("FTP {}", line);
 
         if line.len() < 5 {
             return Err(FtpError::InvalidResponse("error: could not read reply code".to_owned()));
@@ -492,9 +488,7 @@ impl FtpStream {
                 return Err(FtpError::ConnectionError(e));
             }
 
-            if cfg!(feature = "debug_print") {
-                print!("FTP {}", line);
-            }
+            debug!("FTP {}", line);
         }
 
         if expected_code.into_iter().any(|ec| code == *ec) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 
 
 #[macro_use] extern crate lazy_static;
+#[macro_use] extern crate log;
 extern crate regex;
 extern crate chrono;
 


### PR DESCRIPTION
This removes one build configuration flag and uses the `log` crate instead.