### PR TITLE
fix broken doctest for get_ref() on FtpStream

### DIFF
--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -174,14 +174,19 @@ impl FtpStream {
 
     /// Returns a reference to the underlying TcpStream.
     ///
-    /// Example:
-    /// ```no_run
-    /// use std::net::TcpStream;
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use ftp::FtpStream;
+    /// use std::time::Duration;
     ///
     /// let stream = FtpStream::connect("127.0.0.1:21")
-    ///                        .expect("Couldn't connect to the server...");
-    /// stream.get_ref().set_read_timeout(Duration::from_secs(10))
-    ///                 .expect("set_read_timeout call failed");
+    ///     .expect("Couldn't connect to the server...");
+    ///
+    /// stream
+    ///     .get_ref()
+    ///     .set_read_timeout(Some(Duration::from_secs(10)))
+    ///     .expect("set_read_timeout call failed");
     /// ```
     pub fn get_ref(&self) -> &TcpStream {
         self.reader.get_ref().get_ref()


### PR DESCRIPTION
Running `cargo test --features "secure"` fails on the test for `get_ref()` on rust 1.29.1. This wasn't failing before as it was previously ignored according to the last CI build.

I've provided a fix for the test to pass, though this is my first rust PR so please review.