### PR TITLE
Support IPv6 with PASV

### DIFF
--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -263,7 +263,13 @@ impl FtpStream {
                     caps[6].parse::<u8>().unwrap()
                 );
                 let port = ((msb as u16) << 8) + lsb as u16;
-                let ip = IpAddr::V4(Ipv4Addr::new(oct1, oct2, oct3, oct4));
+                let ip = match (oct1, oct2, oct3, oct4) {
+                    // This branch handles IPv6 in particular
+                    (0, 0, 0, 0) =>
+                        self.get_ref().peer_addr().map_err(FtpError::ConnectionError)?.ip(),
+                    _ =>
+                        IpAddr::V4(Ipv4Addr::new(oct1, oct2, oct3, oct4)),
+                };
                 Ok(SocketAddr::new(ip, port))
             })
     }

--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -249,6 +249,8 @@ impl FtpStream {
         PORT_RE.captures(&line)
             .ok_or(FtpError::InvalidResponse(format!("Invalid PASV response: {}", line)))
             .and_then(|caps| {
+                use std::net::{IpAddr, Ipv4Addr};
+
                 // If the regex matches we can be sure groups contains numbers
                 let (oct1, oct2, oct3, oct4) = (
                     caps[1].parse::<u8>().unwrap(),
@@ -261,9 +263,8 @@ impl FtpStream {
                     caps[6].parse::<u8>().unwrap()
                 );
                 let port = ((msb as u16) << 8) + lsb as u16;
-                let addr = format!("{}.{}.{}.{}:{}", oct1, oct2, oct3, oct4, port);
-                SocketAddr::from_str(&addr)
-                    .map_err(|parse_err| FtpError::InvalidAddress(parse_err))
+                let ip = IpAddr::V4(Ipv4Addr::new(oct1, oct2, oct3, oct4));
+                Ok(SocketAddr::new(ip, port))
             })
     }
 


### PR DESCRIPTION
If an FTP connection is made via IPv6, then the IP address returned by the server in response to `PASV` will be all zeros, which will result in a connection error right afterward.

Users can work around this by forcing IPv4 (if they can recognize the problem), or we could fall back to using the connections peer address (whether IPv4 or IPv6). The current pull request implements the latter solution.

Before the current pull request, this code breaks (throws an `FtpError::ConnectionError`) if `ftp.gnu.org` resolves to an IPv6 address :
```rust
let addr = ("ftp.gnu.org", 21);
let mut ftp = FtpStream::connect(addr).unwrap();
ftp.login("anonymous", "").unwrap();
let fname = "/gnu/lightning/lightning-2.1.3.tar.gz";
ftp.list(Some(fname)).unwrap();
```

The error looks like this, where `build.rs:22` refers to the line with `ftp.list`.
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ConnectionError(Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })', build.rs:22:1
```

This is a workaround (see https://github.com/Petelliott/lightning-sys/pull/33) until the current PR is merged :
```rust
// Force IPv4 for now, because the `ftp` crate does not switch to PASV mode
// correctly when connecting over IPv6.
let addr = ("ftp.gnu.org", 21)
    .to_socket_addrs()
    .unwrap()
    .find(|a| match a { std::net::SocketAddr::V4(_) => true, _ => false })
    .unwrap();

let mut ftp = FtpStream::connect(addr).unwrap();
ftp.login("anonymous", "").unwrap();
let fname = "/gnu/lightning/lightning-2.1.3.tar.gz";
ftp.list(Some(fname)).unwrap();
```
