### PR TITLE
Ignore a non-compiling test

### DIFF
--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -175,7 +175,7 @@ impl FtpStream {
     /// Returns a reference to the underlying TcpStream.
     ///
     /// Example:
-    /// ```no_run
+    /// ```ignore
     /// use std::net::TcpStream;
     ///
     /// let stream = FtpStream::connect("127.0.0.1:21")


### PR DESCRIPTION
A `rustdoc` test causes Travis builds to fail gratuitously -- the test is not even compilable (where does `Duration` come from ?), so it should be marked `ignore` instead of `no_run`.