### PR TITLE
Vendored support for Openssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 /Cargo.lock
 *.swp
+**.DS_Store*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 [features]
 # Enable support of FTPS which requires openssl
 secure = ["openssl"]
+vendored = ["openssl/vendored"]
 
 # Add debug output (to STDOUT) of commands sent to the server
 # and lines read from the server
@@ -29,7 +30,7 @@ debug_print = []
 lazy_static = "1"
 regex = "1"
 chrono = "0.4"
-openssl = { version = "0.10", optional = true, features = ["vendored"] }
+openssl = { version = "0.10", optional = true }
 
 [dependencies.native-tls]
 version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ debug_print = []
 lazy_static = "1"
 regex = "1"
 chrono = "0.4"
-openssl = { version = "0.10", optional = true }
+openssl = { version = "0.10", optional = true, features = ["vendored"] }
 
 [dependencies.native-tls]
 version = "0.2"

--- a/README.md
+++ b/README.md
@@ -2,19 +2,6 @@
 
 FTP client for Rust
 
-**THIS IS A FORK**: This fork will fix the following error: 
-```
-error: failed to run custom build command for `openssl v0.9.24`
-
-Caused by:
-  process didn't exit successfully: `/Users/jonaseveraert/Documents/Documenten/KSA/website/html/ftp_conn/target/debug/build/openssl-a27d536a59118df4/build-script-build` (exit status: 101)
-  --- stderr
-  thread 'main' panicked at 'Unable to detect OpenSSL version', /Users/jonaseveraert/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/build.rs:16:14
-  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-warning: build failed, waiting for other jobs to finish...
-error: build failed
-```
-
 [![Number of Crate Downloads](https://img.shields.io/crates/d/ftp.svg)](https://crates.io/crates/ftp)
 [![Crate Version](https://img.shields.io/crates/v/ftp.svg)](https://crates.io/crates/ftp)
 [![Crate License](https://img.shields.io/crates/l/ftp.svg)](https://crates.io/crates/ftp)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 FTP client for Rust
 
+**THIS IS A FORK**: This fork will fix the following error: 
+```
+error: failed to run custom build command for `openssl v0.9.24`
+
+Caused by:
+  process didn't exit successfully: `/Users/jonaseveraert/Documents/Documenten/KSA/website/html/ftp_conn/target/debug/build/openssl-a27d536a59118df4/build-script-build` (exit status: 101)
+  --- stderr
+  thread 'main' panicked at 'Unable to detect OpenSSL version', /Users/jonaseveraert/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/build.rs:16:14
+  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+warning: build failed, waiting for other jobs to finish...
+error: build failed
+```
+
 [![Number of Crate Downloads](https://img.shields.io/crates/d/ftp.svg)](https://crates.io/crates/ftp)
 [![Crate Version](https://img.shields.io/crates/v/ftp.svg)](https://crates.io/crates/ftp)
 [![Crate License](https://img.shields.io/crates/l/ftp.svg)](https://crates.io/crates/ftp)


### PR DESCRIPTION
Hi

## The issue
I was having an issue with this crate which said `Unable to detect OpenSSL version`. After some debugging, I found that the problem was with the openssl crate not using the `Vendored` feature. 

## The changes
I have added another feature called vendored to enable the vendored feature on openssl.