### PR TITLE
Update chrono to pass audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ debug_print = []
 [dependencies]
 lazy_static = "1"
 regex = "1"
-chrono = "0.4"
+chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
 openssl = { version = "0.10", optional = true }
 
 [dependencies.native-tls]


### PR DESCRIPTION
Update `chrono` dependency and reduce its features to pass audit.

```
cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 433 security advisories (from /home/balrog/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (55 crate dependencies)
```